### PR TITLE
Add Open Phoenix Data folder to existing File menu

### DIFF
--- a/Phoenix/Phoenix/ContentView.swift
+++ b/Phoenix/Phoenix/ContentView.swift
@@ -20,6 +20,7 @@ struct ContentView: View {
 
   // The stuff that is actually on screen
   var body: some View {
+    // edit the file menu to add a new menu item called "Open Phoenix Data Folder"
     NavigationSplitView {
       // The sidebar
       GameListView(selectedGame: $selectedGame, refresh: $refresh)

--- a/Phoenix/Phoenix/ContentView.swift
+++ b/Phoenix/Phoenix/ContentView.swift
@@ -20,7 +20,6 @@ struct ContentView: View {
 
   // The stuff that is actually on screen
   var body: some View {
-    // edit the file menu to add a new menu item called "Open Phoenix Data Folder"
     NavigationSplitView {
       // The sidebar
       GameListView(selectedGame: $selectedGame, refresh: $refresh)

--- a/Phoenix/Phoenix/JsonUtils.swift
+++ b/Phoenix/Phoenix/JsonUtils.swift
@@ -18,6 +18,16 @@ func getApplicationSupportDirectory() -> URL {
   return paths[0]
 }
 
+///Returns the Phoenix application support directory
+///
+/// - Returns: The URL for the Application support directory/Phoenix.
+func getPhoenixDirectory() -> URL? {
+    let fileManager = FileManager.default
+    let appSupportDirectory = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+    let phoenixDirectory = appSupportDirectory?.appendingPathComponent("Phoenix")
+    return phoenixDirectory
+}
+
 ///  Parses the appmanifest_<appid>.acf file and returns a dictionary of the key-value pairs.
 ///
 ///    - Parameters:

--- a/Phoenix/Phoenix/PhoenixApp.swift
+++ b/Phoenix/Phoenix/PhoenixApp.swift
@@ -18,6 +18,15 @@ struct PhoenixApp: App {
         .frame(
           minWidth: 800, idealWidth: 1900, maxWidth: .infinity,
           minHeight: 445, idealHeight: 1080, maxHeight: .infinity)
+    }.commands {
+      CommandGroup(replacing: CommandGroupPlacement.newItem) {
+        Button("Open Phoenix Data Folder") {
+          if let phoenixDirectory = getPhoenixDirectory() {
+            NSWorkspace.shared.open(phoenixDirectory)
+              logger.write("[INFO]: Opened Application Support/Phoenix.")
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Adds a quick way for users to access their data and logs. 
Also added a log for when the button is clicked using logger.write()
This replaced the 'New Window' option in the File Menu for Phoenix. 

![image](https://user-images.githubusercontent.com/59124862/211091435-52e9510f-85ce-4fdf-9ede-f9689a586503.png)
![image](https://user-images.githubusercontent.com/59124862/211091512-58942516-e39c-4393-8a5f-8499f20918f4.png)