### PR TITLE
os logs and quit game shell utility function

### DIFF
--- a/Phoenix/Phoenix/CmdUtils.swift
+++ b/Phoenix/Phoenix/CmdUtils.swift
@@ -34,3 +34,23 @@ func shell(_ command: Game) throws {
     print(line, terminator: "")
   }
 }
+
+func quitGame(_ gameName: String) throws {
+  let task = Process()
+  let pipe = Pipe()
+
+  task.standardOutput = pipe
+  task.standardError = pipe
+  task.arguments = ["-c", "pkill \(gameName)"]
+  task.executableURL = URL(fileURLWithPath: "/bin/zsh")
+  task.standardInput = nil
+  logger.write(
+    "[INFO]: Executing command: \(task.arguments!.joined(separator: " ")) to quit game: \(gameName)."
+  )
+  try task.run()
+
+  pipe.fileHandleForReading.readabilityHandler = { fileHandle in
+    guard let line = String(data: fileHandle.availableData, encoding: .utf8) else { return }
+    print(line, terminator: "")
+  }
+}

--- a/Phoenix/Phoenix/PhoenixApp.swift
+++ b/Phoenix/Phoenix/PhoenixApp.swift
@@ -9,9 +9,7 @@ import SwiftUI
 
 @main
 struct PhoenixApp: App {
-  init() {
-    logger.write("[INFO]: Phoenix App Launched.")
-  }
+  @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
   var body: some Scene {
     WindowGroup {
       ContentView()
@@ -28,5 +26,22 @@ struct PhoenixApp: App {
         }
       }
     }
+  }
+}
+class AppDelegate: NSObject, NSApplicationDelegate {
+  func applicationWillFinishLaunching(_ notification: Notification) {
+    logger.write("[INFO]: Phoenix App Launched.")
+  }
+  func applicationDidFinishLaunching(_ notification: Notification) {
+    NSSetUncaughtExceptionHandler { exception in
+      // Log the stack trace to the console
+      print("Uncaught exception: \(exception)")
+      print("Stack trace: \(exception.callStackSymbols.joined(separator: "\n"))")
+    }
+    logger.write("[INFO]: Phoenix App finished launching.")
+  }
+  func applicationWillTerminate(_ aNotification: Notification) {
+    // This method is called when the application is about to terminate. Save data if appropriate.
+    logger.write("[INFO]: Phoenix App shutting down.")
   }
 }

--- a/Phoenix/Phoenix/PhoenixApp.swift
+++ b/Phoenix/Phoenix/PhoenixApp.swift
@@ -30,6 +30,34 @@ struct PhoenixApp: App {
 }
 class AppDelegate: NSObject, NSApplicationDelegate {
   func applicationWillFinishLaunching(_ notification: Notification) {
+    NSSetUncaughtExceptionHandler { exception in
+      // Log the stack trace to the console
+      print("Uncaught exception: \(exception)")
+      print("Stack trace: \(exception.callStackSymbols.joined(separator: "\n"))")
+    }
+    let processInfo = ProcessInfo.processInfo
+    let operatingSystemVersion = processInfo.operatingSystemVersionString
+    let hostName = processInfo.hostName
+    let device = Host.current().localizedName!
+    let userName = NSUserName()
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateStyle = .long
+    dateFormatter.timeStyle = .long
+    let dateString = dateFormatter.string(from: Date())
+    let timeZone = TimeZone.current.identifier
+    let numCores = ProcessInfo.processInfo.activeProcessorCount
+    let memSize = ProcessInfo.processInfo.physicalMemory
+    let appVersion =
+      Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
+    logger.write("[OS]: Operating system version: \(operatingSystemVersion)")
+    logger.write("[OS]: Host name: \(hostName)")
+    logger.write("[OS]: Device: \(device)")
+    logger.write("[OS]: User name: \(userName)")
+    logger.write("[OS]: Date and time: \(dateString)")
+    logger.write("[OS]: Time zone: \(timeZone)")
+    logger.write("[OS]: Number of cores: \(numCores)")
+    logger.write("[OS]: Total RAM available: \(memSize) bytes")
+    logger.write("[OS]: App version: \(appVersion)")
     logger.write("[INFO]: Phoenix App Launched.")
   }
   func applicationDidFinishLaunching(_ notification: Notification) {


### PR DESCRIPTION
The quit game function in CmdUtils could be used by the frontend through a button. (I haven't tried to implement the button) I don't think it would work 100 percent of the time because it uses the name that the user gives to the game, and that might not be the same name as the game process that is running. 