### PR TITLE
Update the app to have no category + fix date problem

### DIFF
--- a/Phoenix/Phoenix.xcodeproj/project.pbxproj
+++ b/Phoenix/Phoenix.xcodeproj/project.pbxproj
@@ -509,7 +509,6 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Phoenix;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -540,7 +539,6 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Phoenix;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Phoenix/Phoenix/EditGameView.swift
+++ b/Phoenix/Phoenix/EditGameView.swift
@@ -254,7 +254,7 @@ struct EditGameView: View {
                 }
 
                 HStack {
-                    DatePicker(selection: $dateInput, in: ...Date.now, displayedComponents: .date) {
+                    DatePicker(selection: $dateInput, in: ...Date(), displayedComponents: .date) {
                         Text("Release Date")
                             .frame(width: 87, alignment: .leading)
                     }
@@ -296,7 +296,8 @@ struct EditGameView: View {
                     if pubInput == "" {
                         pubInput = currentGame.metadata["publisher"] ?? ""
                     }
-                    if dateInput == .now {
+                    // check if the date is today, if yes then change it to the previous release date
+                    if dateInput.formatted(date: .complete, time: .omitted) == Date().formatted(date: .complete, time: .omitted) {
                         dateInputStr = currentGame.metadata["release_date"] ?? ""
                     } else {
                         let dateFormatter: DateFormatter = {


### PR DESCRIPTION
I noticed on the Sonoma beta that Phoenix is classified as a game and therefore has Game Mode which isn't necessary. 
![SCR-20230806-kw4](https://github.com/Shock9616/Phoenix/assets/72482214/bc2e2247-e04d-415e-8aef-1b407cf5b9c3)
This PR removes the games category from the app.


it also fixes issue #31 where the date defaults to today and then replaces the current date
